### PR TITLE
Fix for broken model offset with akimbo weapons

### DIFF
--- a/lua/autorun/client/enhanced_camera.lua
+++ b/lua/autorun/client/enhanced_camera.lua
@@ -349,7 +349,7 @@ function EnhancedCameraTwo:OnPoseChange()
 
 	-- Set pose-specific view offset
 	if self.pose == "normal" or self.pose == "camera" or self.pose == "fist" or
-			self.pose == "dual" or self.pose == "passive" or self.pose == "magic" then
+			self.pose == "duel" or self.pose == "passive" or self.pose == "magic" then
 		self.viewOffset = Vector(-10, 0, -5)
 	elseif self.pose == "melee" or self.pose == "melee2" or
 			self.pose == "grenade" or self.pose == "slam" then


### PR DESCRIPTION
Change 'self.pose == "dual"' to 'self.pose == "duel"', per GMOD SWEP hold type definitions. 
https://wiki.facepunch.com/gmod/Hold_Types